### PR TITLE
Add pandas to setup.py as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setuptools.setup(
     ],
     install_requires=[
         'numpy>=0.13.1',
+        'pandas',
     ],
     package_dir={"": "src"},
     package_data={'':['IGRF13.shc']},


### PR DESCRIPTION
Pandas is needed to run `ppigrf` but was missing from the `setup.py`.