### PR TITLE
Remove wrong minus sign from equation in docstring

### DIFF
--- a/src/ppigrf/ppigrf.py
+++ b/src/ppigrf/ppigrf.py
@@ -620,7 +620,7 @@ def get_inclination_declination(Be, Bn, Bu, degrees=True):
 
     .. math::
 
-        D = - \arcsin \frac{B_e}{\sqrt{B_e^2 + B_n^2}}
+        D = \arcsin \frac{B_e}{\sqrt{B_e^2 + B_n^2}}
 
     Parameters
     ----------


### PR DESCRIPTION
Fix equation for the declination angle in the docstring by removing an unwanted minus sign. Now the docstring matches the implemented equation.