### PR TITLE
Replace missing d2r with np.deg2rad

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="ppigrf",
-    version="2.0.0",
+    version="2.0.1",
     author="Karl Laundal",
     author_email="readme@file.md",
     description="Pure Python IGRF",

--- a/src/ppigrf/ppigrf.py
+++ b/src/ppigrf/ppigrf.py
@@ -670,8 +670,8 @@ def igrf_V(r, theta, phi, date, coeff_fn = shc_fn):
     h = h.interpolate(method = 'time').loc[date, :]
 
     # compute cosmlon and sinmlon:
-    cosmphi = np.cos(phi * d2r * m) # shape (n_coords x n_model_params/2)
-    sinmphi = np.sin(phi * d2r * m)
+    cosmphi = np.cos(np.deg2rad(phi * m)) # shape (n_coords x n_model_params/2)
+    sinmphi = np.sin(np.deg2rad(phi * m))
 
     # make versions of n and m that are repeated twice
     nn, mm = np.tile(n, 2), np.tile(m, 2)


### PR DESCRIPTION
The constant `d2r` in `igrf_V` was not defined, changed to degree-to-radian conversion via the `numpy` function `np.deg2rad`.